### PR TITLE
Hypixel uses multiple IPs for their proxies

### DIFF
--- a/src/main/java/me/semx11/autotip/event/HypixelListener.java
+++ b/src/main/java/me/semx11/autotip/event/HypixelListener.java
@@ -14,7 +14,7 @@ public class HypixelListener {
     @SubscribeEvent
     public void playerLoggedIn(ClientConnectedToServerEvent event) {
         lastIp = UniversalUtil.getRemoteAddress(event).toString().toLowerCase();
-        if (lastIp.contains(".hypixel.net") || lastIp.contains("209.222.115.14")) {
+        if (lastIp.contains(".hypixel.net") || lastIp.startsWith("209.222.115.")) {
             Autotip.onHypixel = true;
             Tipper.waveCounter = 910;
             Autotip.THREAD_POOL.submit(new StartLogin());


### PR DESCRIPTION
https://www.whatsmydns.net/#A/mc.hypixel.net

Hypixel uses many IP addresses for their proxies, not just one, so swapped to a "startsWith" to allow for all 255 addresses Hypixel _could_ use.