### PR TITLE
Fix limbo command

### DIFF
--- a/src/main/java/me/semx11/autotip/command/impl/CommandLimbo.java
+++ b/src/main/java/me/semx11/autotip/command/impl/CommandLimbo.java
@@ -44,7 +44,7 @@ public class CommandLimbo extends CommandAbstract {
 
         if (autotip.getSessionManager().isOnHypixel()) {
             this.executed = true;
-            messageUtil.sendCommand("/achat \u00a7c");
+            messageUtil.sendCommand("/achat \u00a7");
         } else {
             messageUtil.send("&cYou must be on Hypixel to use this command!");
         }


### PR DESCRIPTION
Hypixel recently implemented a fix for a bug in party chat which allowed you to use color codes. This fix works by removing any valid color codes and such we must adjust the limbo command to not be a valid color code. 